### PR TITLE
Makes "listen" parameter optional and minor improvements.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,10 @@
-FROM nikolaik/python-nodejs:python3.10-nodejs17-alpine
+FROM node:lts-alpine
 WORKDIR /app/
 
 COPY package.json yarn.lock ./
 RUN yarn --frozen-lockfile
 
 COPY . .
+
+ARG CONF
 CMD yarn run start -c $CONF

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "polkadot-js-api-ts-template",
+	"name": "polkadot-basic-notification",
 	"version": "0.1.0",
-	"description": "A template project to kickstart hacking on top of @polkadot/api",
+	"description": "A notification system for Substrate based relaychains and its parachains",
 	"main": "index.js",
 	"scripts": {
 		"dev": "./node_modules/.bin/nodemon --exec ./node_modules/.bin/ts-node ./src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,9 +169,9 @@ async function main() {
 	}
 
 	const config: AppConfig = JSON.parse(readFileSync(argv.c).toString());
-	const missingFiled = missingAppConfig(config);
-	if (missingFiled) {
-		logger.error(`missing some key in config file: ${missingFiled}`);
+	const missingField = missingAppConfig(config);
+	if (missingField) {
+		logger.error(`missing some key in config file: ${missingField}`);
 		process.exit(1);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ interface AppConfig {
 	accounts: [string, string][],
 	endpoints: string[],
 	method_subscription: MethodSubscription,
-	listen: ApiSubscription,
+	listen?: any,
 	reporters: ReportersConfig,
 }
 
@@ -77,7 +77,6 @@ function missingAppConfig(arg: any): string {
 	if (!arg.accounts) return "accounts";
 	if (!arg.endpoints) return "endpoints";
 	if (!arg.method_subscription) return "method_subscription";
-	if (!arg.listen) return "listen";
 	if (!arg.reporters) return "reporters";
 	return ""
 }


### PR DESCRIPTION
The configuration example did not show a required "listen" field, this PR makes it optional.
If it is not set in the config, or it has a non 'ApiSubscription' value, it defaults to 'ApiSubscription.Finalized'

Minor improvemens:
package.json used to template values
Renames missingFiled to MissingField in src/index.ts

